### PR TITLE
Remove unnecessary entrypoint/pinning for Pyramid version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ testing_extras = tests_require + [
     'virtualenv', # for scaffolding tests
     ]
 requires = [
-    'pyramid>=1.5a1',
+    'pyramid',
     'Mako>=0.3.6' # strict undefined
 ]
 


### PR DESCRIPTION
We no longer need the entry point since we are doing conditional import in the new `setUp()` in pyramid.testing.

I've also removed the pin for the Pyramid version.
