### PR TITLE
Add an example of how to use unit testing for pyramid_mako

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -167,6 +167,8 @@ renderers are added to the config and can be used.::
             from pyramid.testing import DummyRequest
             request = DummyRequest()
             response = some_view(request)
+            # templates/home.mako starts with the standard <html> tag for HTML5
+            self.assertTrue('<html' in response.body)
 
 
 Reporting Bugs / Development Versions


### PR DESCRIPTION
This adds a simple example that shows how to use config.include() in a
setUp() function for a test to set up the renderers so that they can be
used inside of views that are to be tested.
