### PR TITLE
adding a docs note

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -115,3 +115,5 @@ Bert JW Regeer, 2013-09-03
 Michael Merickel, 2013-10-19
 
 Maxim Avanov, 2014-01-28
+
+Jonathan Vanasco, 2015-01-09

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -184,22 +184,31 @@ variable set to ``1``, For example:
 
 .. note::
 
-	If you are already familiar with the Mako Templating Language...
+    If you are already familiar with the Mako Templating Language, then you
+    should be aware that configuration options for Pyramid and Mako may cause
+    some confusion.
 
-	Pyramid offers a universal `pyramid.reload_templates` setting to manage
-	similar functionality across multiple template systems.
+    Pyramid offers a universal ``pyramid.reload_templates`` setting to manage
+    similar functionality across multiple template systems.
 
-	Pyramid's `reload_templates` is essentially a proxy to Mako's
-	`filesystem_checks` configuration option, with some other internal features
-	built in.  If `reload_templates` is set to  `True`, Pyramid will pass
-	`filesystem_checks = True` to Mako (and vice-versa).
+    Pyramid's ``reload_templates`` is essentially a proxy to Mako's
+    ``filesystem_checks`` configuration option (with support for some other
+    Pyramid-specific features built in).  If ``reload_templates`` is set to
+    ``True``, Pyramid will pass ``filesystem_checks = True`` to Mako (and
+    vice-versa).
 
-	Traditionally in Mako, a `TemplateLookup` instance will have the default
-	value `filesystem_checks = True`.  However, Pyramid's default behvavior is
-	for `reload_templates` to be a `None` value.  The Mako integration of
-	`pyramid_mako` may not initially behave as you expect it would, but by
-	understanding and explicitly configuring this setting, you should be able to
-	better replicate your environment.
+    Traditionally in Mako, a ``TemplateLookup`` instance will have the default
+    value ``filesystem_checks = True`` and one must explicitly disable this
+    behavior.  However, Pyramid's default behvavior is for ``reload_templates``
+    to be ``None``, which Mako will treats as a ``False`` value for this
+    setting.
+
+    Because of this difference, the Mako integration of ``pyramid_mako`` may
+    not initially behave as you expect it would.  Mako's ``filesystem_checks``
+    are disabled by default and must be explicitly enabled by either setting
+    ``pyramid.reload_templates`` to ``true``.  You can also affect
+    ``reload_templates`` with the environment variable
+    ``PYRAMID_RELOAD_TEMPLATES`` as described above.
 
 A Sample Mako Template
 ----------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -182,6 +182,25 @@ variable set to ``1``, For example:
 
    $ PYRAMID_RELOAD_TEMPLATES=1 bin/pserve myproject.ini
 
+.. note::
+
+	If you are already familiar with the Mako Templating Language...
+
+	Pyramid offers a universal `pyramid.reload_templates` setting to manage
+	similar functionality across multiple template systems.
+
+	Pyramid's `reload_templates` is essentially a proxy to Mako's
+	`filesystem_checks` configuration option, with some other internal features
+	built in.  If `reload_templates` is set to  `True`, Pyramid will pass
+	`filesystem_checks = True` to Mako (and vice-versa).
+
+	Traditionally in Mako, a `TemplateLookup` instance will have the default
+	value `filesystem_checks = True`.  However, Pyramid's default behvavior is
+	for `reload_templates` to be a `None` value.  The Mako integration of
+	`pyramid_mako` may not initially behave as you expect it would, but by
+	understanding and explicitly configuring this setting, you should be able to
+	better replicate your environment.
+
 A Sample Mako Template
 ----------------------
 


### PR DESCRIPTION
This drove me crazy for a bit this afternoon, so I figured I would suggest this docs update.

tldr;

1. Pyramid's `reload_templates` populates Mako's `filesystem_checks` argument
2. Pyramid defaults to `None`, while Mako defaults to `True`