### PR TITLE
* is emphasis in rst, it is necessary to escape it.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,7 +22,7 @@
   (https://github.com/Pylons/pyramid_mako/issues/19)
 - Tuple return values in the form of ('defname', {}) are no longer supported,
   and will result in a ValueError being raised.
-- Fix an packaging issue whereby *.foo files were not included in the MANIFEST.
+- Fix an packaging issue whereby \*.foo files were not included in the MANIFEST.
 - Caller-relative template lookup is now supported. Any template that fails
   to be found in the default search paths will be searched relative to the
   caller package.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -119,3 +119,5 @@ Maxim Avanov, 2014-01-28
 Jonathan Vanasco, 2015-01-09
 
 Steve Piercy, 2015-01-20
+
+John Anderson, 2015-04-11

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,10 @@ commands =
     python setup.py nosetests --with-xunit --with-xcoverage
 deps =
     nosexcover
-
 # we separate coverage into its own testenv because a) "last run wins" wrt
 # cobertura jenkins reporting and b) pypy and jython can't handle any
 # combination of versions of coverage and nosexcover that i can find.
 
+[testenv:readme]
+deps = readme
+commands = python setup.py check -r -s


### PR DESCRIPTION
Currently the README on pypi doesn't render:

https://pypi.python.org/pypi/pyramid_mako

This is caused by invalid rst in the CHANGELOG:

```
python setup.py check -r -s
running check
warning: Check: :35: (WARNING/2) Inline emphasis start-string without end-string.

warning: Check: Invalid markup which will not be rendered on PyPI.

error: Please correct your package.
```

