### PR TITLE
Add test of static url

### DIFF
--- a/pyramid_mako/fixtures/static_url.mako
+++ b/pyramid_mako/fixtures/static_url.mako
@@ -1,0 +1,1 @@
+${request.static_url(url)}

--- a/pyramid_mako/tests.py
+++ b/pyramid_mako/tests.py
@@ -629,3 +629,34 @@ class DummyTemplate(object):
 class DummyRendererInfo(object):
     def __init__(self, kw):
         self.__dict__.update(kw)
+
+
+class TestRenderStaticUrl(unittest.TestCase):
+
+    def setUp(self):
+        self.config = testing.setUp()
+        self.config.include('pyramid_mako')
+        self.config.add_static_view('static1', 'bar:static1')
+        self.config.add_static_view('static2', 'static2')
+        self.request = testing.DummyRequest()
+
+    def tearDown(self):
+        self.config.end()
+
+    def test_package_relative_url(self):
+        from pyramid.renderers import render
+        url = 'bar:static1/foo'
+        expected = self.request.static_url(url)
+        result = render('fixtures/static_url.mako',
+                        {'request': self.request, 'url': url})
+
+        self.assertEqual(result.strip(), expected)
+
+    def test_relative_url(self):
+        from pyramid.renderers import render
+        url = 'static2/foo'
+        expected = self.request.static_url(url)
+        result = render('fixtures/static_url.mako',
+                        {'request': self.request, 'url': url})
+
+        self.assertEqual(result.strip(), expected)


### PR DESCRIPTION
Test currently fails on `test_relative_url` to illustrate a [bug report](https://github.com/Pylons/pyramid_mako/issues/32)