### PR TITLE
added `preprocessor_wants_settings` option for settings-aware preprocessor

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 unreleased
 ==================
+
 - Add a config option for ``preprocessor_wants_settings``. If set to ``true``,
   the ``preprocessor`` will be wrapped in a function that invokes the 
   preprocessor with pyramid's config settings as the second argument.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+unreleased
+==================
+- Add a config option for ``preprocessor_wants_settings``. If set to ``true``,
+  the ``preprocessor`` will be wrapped in a function that invokes the 
+  preprocessor with pyramid's config settings as the second argument.
+
 1.0.2 (2014-04-22)
 ==================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -474,6 +474,7 @@ default, this is ``false``.
 |                             |
 +-----------------------------+
 
+
 Mako Preprocessor
 -----------------
 
@@ -481,7 +482,6 @@ A callable (or a :term:`dotted Python name` which names a callable) which is
 called to preprocess the source before the template is called.  The callable
 will be passed the full template source before it is parsed. The return
 result of the callable will be used as the template source code.
-
 
 +-----------------------------+
 | Config File Setting Name    |
@@ -491,6 +491,24 @@ result of the callable will be used as the template source code.
 |                             |
 |                             |
 +-----------------------------+
+
+
+Preprocessor - Pyramid Settings
+------------------------------------
+
+If set to ``true``, the ``mako.preprocessor`` will be wrapped in a function that
+invokes the  preprocessor with pyramid's config settings as the second argument.
+This will allow the preprocessor to act based upon the settings.
+
++----------------------------------------+
+| Config File Setting Name               |
++========================================+
+|  ``mako.preprocessor_wants_settings``  |
+|                                        |
+|                                        |
+|                                        |
++----------------------------------------+
+
 
 Reloading Templates
 -------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -500,6 +500,10 @@ If set to ``true``, the ``mako.preprocessor`` will be wrapped in a function that
 invokes the  preprocessor with pyramid's config settings as the second argument.
 This will allow the preprocessor to act based upon the settings.
 
+	def mako_preprocessor(template, settings):
+	    template = template.replace("foo", settings.get("foo_replacement"))
+	    return template
+
 +----------------------------------------+
 | Config File Setting Name               |
 +========================================+

--- a/pyramid_mako/__init__.py
+++ b/pyramid_mako/__init__.py
@@ -191,6 +191,7 @@ def parse_options_from_settings(settings, settings_prefix, maybe_dotted):
     future_imports = sget('future_imports', None)
     strict_undefined = asbool(sget('strict_undefined', False))
     preprocessor = sget('preprocessor', None)
+    preprocessor_wants_settings = asbool(sget('preprocessor_wants_settings', None))
     if not is_nonstr_iter(directories):
         # Since we parse a value that comes from an .ini config,
         # we treat whitespaces and newline characters equally as list item separators.
@@ -216,7 +217,13 @@ def parse_options_from_settings(settings, settings_prefix, maybe_dotted):
             future_imports = aslist(future_imports)
 
     if preprocessor is not None:
-        preprocessor = maybe_dotted(preprocessor)
+        preprocessor_function = maybe_dotted(preprocessor)
+        if preprocessor_wants_settings:
+            def preprocessor_injector(template):
+                return preprocessor_function(template, settings)
+            preprocessor = preprocessor_injector
+        else:
+            preprocessor = preprocessor_function
 
     return dict(
         directories=directories,

--- a/pyramid_mako/tests.py
+++ b/pyramid_mako/tests.py
@@ -114,6 +114,23 @@ class TestMakoRendererFactory(Base, unittest.TestCase):
         self.assertEqual(renderer.template.path, 'hello .world.mako')
         self.assertEqual(renderer.defname, 'comp')
 
+class TestIntegrationWithPreprocessorSettings(unittest.TestCase):
+    def setUp(self):
+        self.config = testing.setUp()
+        self.settings = {'mako.directories': 'pyramid_mako.tests:fixtures',
+                         'mako.preprocessor': 
+                         'pyramid_mako.tests.dummy_mako_preprocessor',
+                         'mako.preprocessor_wants_settings': 'true',
+                         'replace_Hello': 'Goodbye',
+                         }
+        self.config.add_settings(self.settings)
+        self.config.include('pyramid_mako')
+
+    def test_with_preprocessor_settings(self):
+        from pyramid.renderers import render
+        rendered = render('helloinherit.mak', {}).replace('\r', '')
+        self.assertTrue(self.settings['replace_Hello'] in rendered)
+
 class Test_parse_options_from_settings(Base, unittest.TestCase):
     def _callFUT(self, settings, settings_prefix='mako.'):
         from pyramid_mako import parse_options_from_settings
@@ -193,19 +210,22 @@ class Test_parse_options_from_settings(Base, unittest.TestCase):
         otherwise we check it doesn't change on false-ish values.
         """
         import pyramid_mako.tests
+
+        # test args True
         settings = {'mako.directories': self.templates_dir,
                     'mako.preprocessor': 'pyramid_mako.tests',
                     'mako.preprocessor_wants_settings': 'true',
                     }
-        result = self._callFUT(settings)
-        self.assertEqual(result['preprocessor'].__name__, 'preprocessor_injector')
+        renderer = self._callFUT(settings)
+        self.assertEqual(renderer['preprocessor'].__name__, 'preprocessor_injector')
 
+        # test args False
         settings2 = {'mako.directories': self.templates_dir,
                      'mako.preprocessor': 'pyramid_mako.tests',
                      'mako.preprocessor_wants_settings': 'false',
                      }
-        result2 = self._callFUT(settings2)
-        self.assertEqual(result2['preprocessor'], pyramid_mako.tests)
+        renderer2 = self._callFUT(settings2)
+        self.assertEqual(renderer2['preprocessor'], pyramid_mako.tests)
 
     def test_with_default_filters(self):
         settings = {'mako.directories': self.templates_dir,
@@ -649,3 +669,9 @@ class DummyTemplate(object):
 class DummyRendererInfo(object):
     def __init__(self, kw):
         self.__dict__.update(kw)
+
+def dummy_mako_preprocessor(template, settings):
+    # demo preprocessor function
+    template = template.replace("Hello", settings.get('replace_Hello', ''))
+    return template
+

--- a/pyramid_mako/tests.py
+++ b/pyramid_mako/tests.py
@@ -187,6 +187,26 @@ class Test_parse_options_from_settings(Base, unittest.TestCase):
         result = self._callFUT(settings)
         self.assertEqual(result['preprocessor'], pyramid_mako.tests)
 
+    def test_with_preprocessor_settings(self):
+        """
+        first we check to ensure the name is replaced on true-ish value.
+        otherwise we check it doesn't change on false-ish values.
+        """
+        import pyramid_mako.tests
+        settings = {'mako.directories': self.templates_dir,
+                    'mako.preprocessor': 'pyramid_mako.tests',
+                    'mako.preprocessor_wants_settings': 'true',
+                    }
+        result = self._callFUT(settings)
+        self.assertEqual(result['preprocessor'].__name__, 'preprocessor_injector')
+
+        settings2 = {'mako.directories': self.templates_dir,
+                     'mako.preprocessor': 'pyramid_mako.tests',
+                     'mako.preprocessor_wants_settings': 'false',
+                     }
+        result2 = self._callFUT(settings2)
+        self.assertEqual(result2['preprocessor'], pyramid_mako.tests)
+
     def test_with_default_filters(self):
         settings = {'mako.directories': self.templates_dir,
                     'mako.default_filters': '\nh\ng\n\n'}


### PR DESCRIPTION
The mako preprocessor is not as useful as it could be without access to pyramid's settings object.

This PR adds support for a `mako.preprocessor_wants_settings` option in `environment.ini`  by wrapping the function at configuration time (as opposed to using the threadlocal tasks within the preprocessor).

If set to a true-ish value (via `asbool()`), the preprocessor is replaced with a `preprocessor_injector` function that accepts a single "template" argument from Mako... but then invokes the userland `preprocessor` with an extra argument for `settings`.  (this could have been a lambda, but it was easier to test)
