### PR TITLE
Add cache_args to config file

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -123,3 +123,5 @@ Steve Piercy, 2015-01-20
 John Anderson, 2015-04-11
 
 Caleb P. Burns, 2019-03-14
+
+Slavik Nychkalo, 2019-03-20

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -370,9 +370,6 @@ The values supplied here are passed in ``TemplateLookup`` as the ``cache_args``.
 |  ``mako.cache.url``         |
 +-----------------------------+
 |  ``mako.cache.dir``         |
-|                             |
-|                             |
-|                             |
 +-----------------------------+
 
 Mako Module Directory

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -353,6 +353,28 @@ to the location of the ``my.package`` Python package.
 |                             |
 +-----------------------------+
 
+Mako Caching
+----------------
+
+The values supplied here are passed in ``TemplateLookup`` as the ``cache_args``. 
+`More docs about caching in Mako
+<https://docs.makotemplates.org/en/latest/caching.html>`_.
+
++-----------------------------+
+| Config File Setting Name    |
++=============================+
+|  ``mako.cache.timeout``     |
++-----------------------------+
+|  ``mako.cache.type``        |
++-----------------------------+
+|  ``mako.cache.url``         |
++-----------------------------+
+|  ``mako.cache.dir``         |
+|                             |
+|                             |
+|                             |
++-----------------------------+
+
 Mako Module Directory
 ---------------------
 

--- a/pyramid_mako/__init__.py
+++ b/pyramid_mako/__init__.py
@@ -192,6 +192,10 @@ def parse_options_from_settings(settings, settings_prefix, maybe_dotted):
     strict_undefined = asbool(sget('strict_undefined', False))
     preprocessor = sget('preprocessor', None)
     preprocessor_wants_settings = asbool(sget('preprocessor_wants_settings', None))
+    cache_type = sget('cache.type', None)
+    cache_dir = sget('cache.dir', module_directory)
+    cache_timeout = sget('cache.timeout', None)
+    cache_url = sget('cache.url', None)
     if not is_nonstr_iter(directories):
         # Since we parse a value that comes from an .ini config,
         # we treat whitespaces and newline characters equally as list item separators.
@@ -236,6 +240,12 @@ def parse_options_from_settings(settings, settings_prefix, maybe_dotted):
         filesystem_checks=reload_templates,
         strict_undefined=strict_undefined,
         preprocessor=preprocessor,
+        cache_args=dict(
+            timeout=cache_timeout,
+            url=cache_url,
+            type=cache_type,
+            dir=cache_dir,
+        )
     )
 
 def add_mako_renderer(config, extension, settings_prefix='mako.'):


### PR DESCRIPTION
According to [Mako caching docs](https://docs.makotemplates.org/en/latest/caching.html#using-the-beaker-cache-backend) we can pass `cache_args` to TemplateLookup as argument to set `timeout`, `url`, `type` and `dir` for caching

According to this:
![Screen Shot 2019-03-20 at 6 33 06 PM](https://user-images.githubusercontent.com/13422799/54701968-a6341f00-4b3e-11e9-8de1-3203cf059dfb.png)
use `module_directory` as fallback for `cache.dir`


We couldn't do it in `pyramid_mako`
But now we can 😄, and we need it, I really need it in my current project
