### PR TITLE
Remove remaining references to pyramid.compat

### DIFF
--- a/pyramid_mako/fixtures/hello .world.mako
+++ b/pyramid_mako/fixtures/hello .world.mako
@@ -1,3 +1,3 @@
 ## -*- coding: utf-8 -*-
-<%!from pyramid.compat import text_%><% a, b = 'foo', text_('föö', 'utf-8') %>
+<%!from pyramid_mako.compat import text_%><% a, b = 'foo', text_('föö', 'utf-8') %>
 Hello ${text_('föö', 'utf-8')}

--- a/pyramid_mako/fixtures/helloworld.mak
+++ b/pyramid_mako/fixtures/helloworld.mak
@@ -1,3 +1,3 @@
 ## -*- coding: utf-8 -*-
-<%!from pyramid.compat import text_%><% a, b = 'foo', text_('föö', 'utf-8') %>
+<%!from pyramid_mako.compat import text_%><% a, b = 'foo', text_('föö', 'utf-8') %>
 Hello ${text_('föö', 'utf-8')}

--- a/pyramid_mako/fixtures/helloworld.mako
+++ b/pyramid_mako/fixtures/helloworld.mako
@@ -1,3 +1,3 @@
 ## -*- coding: utf-8 -*-
-<%!from pyramid.compat import text_%><% a, b = 'foo', text_('föö', 'utf-8') %>
+<%!from pyramid_mako.compat import text_%><% a, b = 'foo', text_('föö', 'utf-8') %>
 Hello ${text_('föö', 'utf-8')}


### PR DESCRIPTION
Fixes #53 by removing the last remaining references to `pyramid.compat` that were missed in #48.